### PR TITLE
installing ssl dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:18.04
 RUN apt-get update -y
 RUN apt-get install -y build-essential
 RUN apt-get install -y wget
+RUN apt-get install -y openssl libssl-dev
 RUN wget http://www.live555.com/liveMedia/public/live555-latest.tar.gz
 RUN tar -xzf live555-latest.tar.gz
 COPY /OutPacketBuffer.diff /
@@ -13,6 +14,7 @@ RUN make
 
 FROM ubuntu:18.04
 RUN apt-get update -y
+RUN apt-get install -y openssl 
 COPY --from=0 /live/proxyServer/live555ProxyServer /usr/bin
 WORKDIR /
 ADD /startup.sh /


### PR DESCRIPTION
installing openssl libssl-dev on build
installing openssl on actual worker container 

without these changes build container failed to init and worker container was getting runtime error - `error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory`